### PR TITLE
Remove strict json requirement from metadata description

### DIFF
--- a/content/metadata.md
+++ b/content/metadata.md
@@ -15,7 +15,8 @@ The signed metadata files always include an expiration date. This ensures
 that outdated metadata will be detected and that
 clients can refuse to accept metadata older than that which they've already seen.
 
-All TUF metadata uses a subset of the JSON object format. When calculating the
+Implementers of TUF may use any data format for metadata files. The examples
+here use a subset of the JSON object format. When calculating the
 digest of an object, we use the [Canonical JSON](http://wiki.laptop.org/go/Canonical_JSON) format. Implementation-level detail about the metadata can be found in the [spec](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md).
 
 There are four required top-level roles, each with their own metadata file.


### PR DESCRIPTION
Addresses part of theupdateframework/specification#101 by removing the json requirement from the website. As discussed in theupdateframework/specification#101, TUF allows for any metadata file format, but examples in the specification and on the website use canonical JSON. 

I did not include the canonicalization requirement here as this passage links back to the specification, but can add that if others think it is needed.