### PR TITLE
Add tuf Slack channel to contacts page

### DIFF
--- a/content/contact.md
+++ b/content/contact.md
@@ -6,7 +6,9 @@ Please contact us via our [mailing
 list](https://groups.google.com/forum/?fromgroups#!forum/theupdateframework).
 
 Questions, feedback, and suggestions are welcomed on this low volume mailing
-list.  We strive to make the specification easy to implement, so if you come
-across any inconsistencies or experience any difficulty, do let us know by
-sending an email, or by reporting an issue in the [specification
-repo](https://github.com/theupdateframework/specification/issues).
+list or the [#tuf](https://cloud-native.slack.com/archives/C8NMD3QJ3) channel
+on [CNCF Slack](https://slack.cncf.io/).  We strive to make the specification
+easy to implement, so if you come across any inconsistencies or experience any
+difficulty, do let us know by sending an email, or by reporting an issue in
+the [specification
+ repo](https://github.com/theupdateframework/specification/issues).


### PR DESCRIPTION
Address #7 by adding a link to the #tuf Slack channel to the contact page