### PR TITLE
Fix spec links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -97,7 +97,7 @@ weight = 3
 [[menu.main]]
 name = "Specification"
 parent = "getting-started"
-url = "https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#the-update-framework-specification"
+url = "https://github.com/theupdateframework/specification/blob/master/tuf-spec.md"
 weight = 4
 
 [[menu.main]]

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,6 @@
 ---
 ---
 
-The Update Framework (**TUF**) helps developers maintain the security of software update systems, providing protection even against attackers that compromise the repository or signing keys. TUF provides a flexible framework and [specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#the-update-framework-specification) that developers can adopt into any software update system.
+The Update Framework (**TUF**) helps developers maintain the security of software update systems, providing protection even against attackers that compromise the repository or signing keys. TUF provides a flexible framework and [specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) that developers can adopt into any software update system.
 
 TUF is hosted by the [Linux Foundation](https://www.linuxfoundation.org/) as part of the [Cloud Native Computing Foundation](https://www.cncf.io) (CNCF) and is [used in production](/adoptions) by various tech companies and open source organizations. A variant of TUF called [Uptane](https://uptane.github.io/) is widely used to secure over-the-air updates in automobiles.

--- a/content/faq.md
+++ b/content/faq.md
@@ -16,7 +16,7 @@ title: Frequently Asked Questions
 
   For (2), an adopter has to figure out how to ship the initial Root file, and
   implement [the TUF download and verification
-  workflow](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#5-detailed-workflows)
+  workflow](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#detailed-client-workflow--detailed-client-workflow)
   in their language of choice if one of the existing implementations is
   insufficient.
 


### PR DESCRIPTION
Some of the anchors in the specification have changed since the conversion to bikeshed flavoured markdown.

Note: we will want to make some changes again once the rendered version of the specification is published to GitHub pages (see https://github.com/theupdateframework/specification/pull/148)