### PR TITLE
Point to the rendered specification on GitHub Pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -101,16 +101,23 @@ url = "https://theupdateframework.github.io/specification/latest/"
 weight = 4
 
 [[menu.main]]
+name = "Specification index"
+parent = "getting-started"
+url = "https://theupdateframework.github.io/specification/"
+weight = 5
+
+
+[[menu.main]]
 name = "Implementation"
 parent = "getting-started"
 url = "https://github.com/theupdateframework/tuf/blob/develop/docs/GETTING_STARTED.rst#getting-started"
-weight = 5
+weight = 6
 
 [[menu.main]]
 name = "Videos"
 parent = "getting-started"
 url = "/videos"
-weight = 6
+weight = 7
 
 [[menu.main]]
 name = "Community"

--- a/config.toml
+++ b/config.toml
@@ -95,9 +95,9 @@ url = "/faq"
 weight = 3
 
 [[menu.main]]
-name = "Specification"
+name = "Specification (latest)"
 parent = "getting-started"
-url = "https://github.com/theupdateframework/specification/blob/master/tuf-spec.md"
+url = "https://theupdateframework.github.io/specification/latest/"
 weight = 4
 
 [[menu.main]]

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,6 @@
 ---
 ---
 
-The Update Framework (**TUF**) helps developers maintain the security of software update systems, providing protection even against attackers that compromise the repository or signing keys. TUF provides a flexible framework and [specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) that developers can adopt into any software update system.
+The Update Framework (**TUF**) helps developers maintain the security of software update systems, providing protection even against attackers that compromise the repository or signing keys. TUF provides a flexible framework and [specification](https://theupdateframework.github.io/specification/latest/) that developers can adopt into any software update system.
 
 TUF is hosted by the [Linux Foundation](https://www.linuxfoundation.org/) as part of the [Cloud Native Computing Foundation](https://www.cncf.io) (CNCF) and is [used in production](/adoptions) by various tech companies and open source organizations. A variant of TUF called [Uptane](https://uptane.github.io/) is widely used to secure over-the-air updates in automobiles.

--- a/content/faq.md
+++ b/content/faq.md
@@ -16,7 +16,7 @@ title: Frequently Asked Questions
 
   For (2), an adopter has to figure out how to ship the initial Root file, and
   implement [the TUF download and verification
-  workflow](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#detailed-client-workflow--detailed-client-workflow)
+  workflow](https://theupdateframework.github.io/specification/latest/#detailed-client-workflow)
   in their language of choice if one of the existing implementations is
   insufficient.
 


### PR DESCRIPTION
Now that we have a workflow to build and publish the bikesehd generated document, consistent point users to that version of the specification.

Fixes #19