### PR TITLE
Add a couple of ~recent news items

### DIFF
--- a/content/news.md
+++ b/content/news.md
@@ -6,7 +6,7 @@ title: News
 
 **June 16, 2021**
 
-The Sigstore community live-streams [key generation and signing ceremony
+The Sigstore community live-streamed a [key generation and signing ceremony
 ](https://www.cncf.io/blog/2021/06/16/a-new-kind-of-trust-root/) for the
 Sigstore trust root, which is using The Update Framework (TUF) primitives to
 provide a PKI model with no single entity in charge of the trust root, and

--- a/content/news.md
+++ b/content/news.md
@@ -4,6 +4,14 @@ title: News
 
 > The [press](/press) page contains a full listing of news coverage.
 
+**June 16, 2021**
+
+The Sigstore community live-streams [key generation and signing ceremony
+](https://www.cncf.io/blog/2021/06/16/a-new-kind-of-trust-root/) for the
+Sigstore trust root, which is using The Update Framework (TUF) primitives to
+provide a PKI model with no single entity in charge of the trust root, and
+shorter root key lifespan than traditional PKI models.
+
 **March 5, 2021**
 
 The [TUF specification](https://theupdateframework.github.io/specification/latest/index.html)

--- a/content/news.md
+++ b/content/news.md
@@ -4,6 +4,16 @@ title: News
 
 > The [press](/press) page contains a full listing of news coverage.
 
+**March 5, 2021**
+
+The [TUF specification](https://theupdateframework.github.io/specification/latest/index.html)
+is now published as a rich HTML document with a table of contents, syntax
+highlighting, cross-linking, and other features.
+
+The new publication machinery also maintains a [list of all versions
+](https://theupdateframework.github.io/specification/) published since the
+format change.
+
 **October 30, 2020**
 
 The Python Software Foundation live-streams a [key generation and signing ceremony](https://www.youtube.com/watch?v=jjAq7S49eow&t=3078s) that marks the first practical steps in deploying The Update Framework (TUF) to the [Python Package Index](pypi.org).  

--- a/content/news.md
+++ b/content/news.md
@@ -10,7 +10,7 @@ The Python Software Foundation live-streams a [key generation and signing ceremo
 
 **February 15, 2020**
 
-[PEP 458](https://www.python.org/dev/peps/pep-0458/), Secure PyPI Downloads with Package Signing, is accepted and merged into the Python master.
+[PEP 458](https://www.python.org/dev/peps/pep-0458/), Secure PyPI Downloads with Package Signing, is accepted and merged into the Python Enhancement Proposals (PEP) tree.
 
 **December 19, 2019**
 


### PR DESCRIPTION
Add news entries for:
* New spec format and auto-publishing
* TUF primitives powering Sigstore's trust root