### PR TITLE
Update for ref impl repo rename to python-tuf

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -110,7 +110,7 @@ weight = 5
 [[menu.main]]
 name = "Implementation"
 parent = "getting-started"
-url = "https://github.com/theupdateframework/tuf/blob/develop/docs/GETTING_STARTED.rst#getting-started"
+url = "https://github.com/theupdateframework/python-tuf/blob/develop/docs/GETTING_STARTED.rst#getting-started"
 weight = 6
 
 [[menu.main]]
@@ -151,7 +151,7 @@ weight = 4
 [[menu.main]]
 name = "Contribute"
 parent = "community"
-url = "https://github.com/theupdateframework/tuf"
+url = "https://github.com/theupdateframework/python-tuf"
 weight = 5
 
 [[menu.main]]

--- a/content/faq.md
+++ b/content/faq.md
@@ -114,7 +114,7 @@ title: Frequently Asked Questions
   the bandwidth associated with downloading the large file many times can be
   saved.  The reference implementation provides an [easy way to distribute
   target files across many targets
-  metadata](https://github.com/theupdateframework/tuf/blob/d4b308ae13acfe832bfb7f993108e5e065d44c04/tuf/repository_tool.py#L2387)
+  metadata](https://github.com/theupdateframework/python-tuf/blob/d4b308ae13acfe832bfb7f993108e5e065d44c04/tuf/repository_tool.py#L2387)
   (i.e., delegating to hashed bins), which the
   [specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md)
   refers to as path hash prefixes.
@@ -146,7 +146,7 @@ title: Frequently Asked Questions
 **13. How can I try TUF?**
 
   The [Getting
-  Started](https://github.com/theupdateframework/tuf/blob/develop/docs/GETTING_STARTED.rst)
+  Started](https://github.com/theupdateframework/python-tuf/blob/develop/docs/GETTING_STARTED.rst)
   page contains instructions to install and run the reference implementation.
   The client and repo tools can be used to quickly create TUF repositories and
   experiment with software updates.

--- a/content/project.md
+++ b/content/project.md
@@ -19,7 +19,7 @@ community who have [contributed] to the TUF project over the years.
 Please visit the [governance page] to learn how project decisions are made, and
 for a more detailed explanation of the project roles used below.
 
-[contributed]: https://github.com/theupdateframework/tuf/blob/develop/docs/AUTHORS.txt
+[contributed]: https://github.com/theupdateframework/python-tuf/blob/develop/docs/AUTHORS.txt
 [governance page]: https://github.com/theupdateframework/specification/blob/master/GOVERNANCE.md
 [Specification]: /specification
 [Standardization process]: https://github.com/theupdateframework/taps/blob/master/tap1.md


### PR DESCRIPTION
We are planning to rename the reference implementation from tuf->python-tuf, this PR updates links to the reference implementation and should be merged after the change is made.