### PR TITLE
add a "Chat (CNCF Slack)" submenu item in "Community"

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -155,6 +155,12 @@ url = "https://github.com/theupdateframework/python-tuf"
 weight = 5
 
 [[menu.main]]
+name = "Chat (CNCF Slack)"
+parent = "community"
+url = "https://cloud-native.slack.com/archives/C8NMD3QJ3"
+weight = 6
+
+[[menu.main]]
 name = "News"
 url = "/news/"
 weight = 4


### PR DESCRIPTION
Adding a "chat" submenu item in the Community menu should help people find the chat.
It's also in contact, but can make it sound like it's the place to reach the project itself (ie: maintainers) and not the community as a whole.