### PR TITLE
Fix the contributing link to redirect to the specification repository

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -151,7 +151,7 @@ weight = 4
 [[menu.main]]
 name = "Contribute"
 parent = "community"
-url = "https://github.com/theupdateframework/python-tuf"
+url = "https://github.com/theupdateframework/specification"
 weight = 5
 
 [[menu.main]]


### PR DESCRIPTION
Instead of going to the specification repository, the contributing link redirects to the reference implementation.

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>