### PR TITLE
Update references to python-tuf repo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -108,9 +108,9 @@ weight = 5
 
 
 [[menu.main]]
-name = "Implementation"
+name = "Reference implementation"
 parent = "getting-started"
-url = "https://github.com/theupdateframework/python-tuf/blob/develop/docs/GETTING_STARTED.rst#getting-started"
+url = "https://github.com/theupdateframework/python-tuf"
 weight = 6
 
 [[menu.main]]

--- a/content/faq.md
+++ b/content/faq.md
@@ -114,10 +114,10 @@ title: Frequently Asked Questions
   the bandwidth associated with downloading the large file many times can be
   saved.  The reference implementation provides an [easy way to distribute
   target files across many targets
-  metadata](https://github.com/theupdateframework/python-tuf/blob/d4b308ae13acfe832bfb7f993108e5e065d44c04/tuf/repository_tool.py#L2387)
-  (i.e., delegating to hashed bins), which the
-  [specification](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md)
-  refers to as path hash prefixes.
+  metadata](https://github.com/theupdateframework/python-tuf/blob/v0.20.0/examples/repo_example/hashed_bin_delegation.py)
+  (i.e., delegating to hashed bins), which the specification refers to as [path
+  hash
+  prefixes](https://theupdateframework.github.io/specification/latest/#path_hash_prefixes).
 
 **10. Can TUF be used with devices that lack the CPU power or memory to
   verify metadata?**
@@ -145,11 +145,12 @@ title: Frequently Asked Questions
 
 **13. How can I try TUF?**
 
-  The [Getting
-  Started](https://github.com/theupdateframework/python-tuf/blob/develop/docs/GETTING_STARTED.rst)
-  page contains instructions to install and run the reference implementation.
-  The client and repo tools can be used to quickly create TUF repositories and
-  experiment with software updates.
+  The `python-tuf` reference implementation provides a [well-documented
+  API](https://theupdateframework.readthedocs.io/en/latest/api/api-reference.html)
+  to create and manage TUF metadata on a server-side repository, and to perform
+  TUF-compliant updates on a client, as well as basic Python [code
+  examples](https://github.com/theupdateframework/python-tuf/tree/develop/examples)
+  that demonstrate the usage.
 
 **14. Is there a presentation or video about TUF?**
 


### PR DESCRIPTION
In [preparation for the 1.0.0 release](https://github.com/theupdateframework/python-tuf/blob/ecc1cb08b8478f2825dda581f7c734a40500eca4/docs/1.0.0-ANNOUNCEMENT.md) of the TUF reference
implementation python-tuf documentation linked on the TUF
website is being moved. This patch updates these links. In
particular:

- In menu item "Getting started"
Point to "Reference implementation" repo instead of "Implementation
Getting Started" page. The Getting Started page is being
deprecated, and the repo (i.e. README.md) should be just as
informative.

- In "FAQ: Are there ways to reduce bandwidth costs?"
Point to new hashed bin delegation example and specific section in
spec (old tutorial is deprecated)

- In "FAQ: 13. How can I try TUF?"
Point to API reference on RTD and up-to-date source code examples
in python-tuf (getting started is deprecated)

Signed-off-by: Lukas Puehringer <lukas.puehringer@nyu.edu>