### PR TITLE
Configure https security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,3 +22,12 @@ to = "https://theupdateframework.github.io/specification/"
 [[redirects]]
 from = "/specification"
 to = "https://theupdateframework.github.io/specification/latest/"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self' code.jquery.com fonts.googleapis.com fonts.gstatic.com use.fontawesome.com"
+    X-Frame-Options = "deny"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "no-referrer-when-downgrade"
+    permissions-policy = "interest-cohort=()"

--- a/netlify.toml
+++ b/netlify.toml
@@ -26,7 +26,7 @@ to = "https://theupdateframework.github.io/specification/latest/"
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self' code.jquery.com fonts.googleapis.com fonts.gstatic.com use.fontawesome.com"
+    Content-Security-Policy = "default-src 'self' code.jquery.com fonts.googleapis.com fonts.gstatic.com use.fontawesome.com app.netlify.com netlify-cdp-loader.netlify.app"
     X-Frame-Options = "deny"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "no-referrer-when-downgrade"


### PR DESCRIPTION
The following headers are added:

Content-Security-Policy: allow loading any content from jquery (js),
  and google and fontawesome (fonts and style).
X-Frame-Options: Don't allow iframes
X-Content-Type-Options: stop browser from trying to MIME-sniff the
  content type and force it to stick with the declared content-type.
Referrer-Policy: Don't include referrer path in when moving from
  https to http.
Permissions-Policy: Disallow FloC Web-Tracking (experimental)

See scan result and details about individual headers on:
https://securityheaders.com/?q=https%3A%2F%2Ftheupdateframework.io

Cheers to @adityasaky and his model PR in in-toto/in-toto.io#7

Signed-off-by: Lukas Puehringer <lukas.puehringer@nyu.edu>