### PR TITLE
Updated CSP header to allow embedded youtube

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,7 +26,7 @@ to = "https://theupdateframework.github.io/specification/latest/"
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self' code.jquery.com fonts.googleapis.com fonts.gstatic.com use.fontawesome.com app.netlify.com netlify-cdp-loader.netlify.app"
+    Content-Security-Policy = "default-src 'self' code.jquery.com fonts.googleapis.com fonts.gstatic.com use.fontawesome.com app.netlify.com netlify-cdp-loader.netlify.app youtube.com; frame-src youtube.com www.youtube.com"
     X-Frame-Options = "deny"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "no-referrer-when-downgrade"


### PR DESCRIPTION
Following #11  we need to whitelist youtube in our CSP headers to allow embedding videos in iframes.