### PR TITLE
fix url parser

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -8,12 +8,12 @@
 {{ $fontSlice = $fontSlice | append (printf "%s:%s" (replace .name " " "+") (delimit .sizes ",")) }}
 {{ end }}
 {{ $fontsUrl := printf "https://fonts.googleapis.com/css?family=%s" (delimit $fontSlice "|") }}
-@import url({{ $fontsUrl }})
+@import url("{{ $fontsUrl }}")
 {{ end }}
 
 {{ with $fontAwesomeVersion }}
 {{ $fontAwesomeUrl := printf "https://use.fontawesome.com/releases/v%s/css/all.css" . }}
-@import url({{ $fontAwesomeUrl }})
+@import url("{{ $fontAwesomeUrl }}")
 {{ end }}
 
 // Site-specific variables here


### PR DESCRIPTION
We are getting this error on running website https://theupdateframework.io/ locally,
````
$ hugo server
WARN  DEPRECATED: Kind "taxonomyterm" used in disableKinds is deprecated, use "taxonomy" instead.
Watching for changes in ../theupdateframework.io/{assets,content,data,layouts,package.json,static}
Watching for config changes in ../theupdateframework.io/config.toml
Start building sites …
hugo v0.126.1-3d40aba512931031921463dafc172c0d124437b8+extended linux/amd64 BuildDate=2024-05-15T10:42:34Z VendorInfo=snap:0.126.1

WARN  deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in a future release. Use hugo.IsServer instead.
ERROR TOCSS: failed to transform "sass/style.sass" (text/x-sass): "../theupdateframework.io/assets/sass/style.sass:13:9": malformed URL
Built in 1762 ms
Error: error building site: TOCSS: failed to transform "sass/style.sass" (text/x-sass): "../theupdateframework.io/assets/sass/style.sass:13:9": malformed URL
````
Hence we need to fix this by passing URL as a string. 