### PR TITLE
adding GitHub option on our website

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -163,9 +163,9 @@ weight = 6
 [[menu.main]]
 name = "News"
 url = "/news/"
-weight = 5
+weight = 4
 
 [[menu.main]]
 name = "Contact"
 url = "/contact/"
-weight = 6
+weight = 5

--- a/config.toml
+++ b/config.toml
@@ -31,14 +31,9 @@ sizes = [300, 400, 600, 700]
 type = "monospace"
 
 [[menu.main]]
-name = "GitHub"
-url = "/github/"
-weight = 1
-
-[[menu.main]]
 name = "About"
 identifier = "about"
-weight = 2
+weight = 1
 
 [[menu.main]]
 name = "Overview"
@@ -59,15 +54,15 @@ url = "/timeline"
 weight = 3
 
 [[menu.main]]
-name = "Publications"
-parent = "about"
-url = "/publications"
-weight = 5
-
-[[menu.main]]
 name = "Project"
 parent = "about"
 url = "/project"
+weight = 4
+
+[[menu.main]]
+name = "Publications"
+parent = "about"
+url = "/publications"
 weight = 5
 
 [[menu.main]]
@@ -79,7 +74,7 @@ weight = 6
 [[menu.main]]
 name = "Getting started"
 identifier = "getting-started"
-weight = 3
+weight = 2
 
 [[menu.main]]
 name = "Security"
@@ -127,7 +122,7 @@ weight = 7
 [[menu.main]]
 name = "Community"
 identifier = "community"
-weight = 4
+weight = 3
 
 [[menu.main]]
 name = "Adoptions"
@@ -160,9 +155,9 @@ url = "https://github.com/theupdateframework/python-tuf"
 weight = 5
 
 [[menu.main]]
-name = "Chat (CNCF Slack)"
+name = "GitHub"
 parent = "community"
-url = "https://cloud-native.slack.com/archives/C8NMD3QJ3"
+url = "/github"
 weight = 6
 
 [[menu.main]]

--- a/config.toml
+++ b/config.toml
@@ -31,9 +31,14 @@ sizes = [300, 400, 600, 700]
 type = "monospace"
 
 [[menu.main]]
+name = "GitHub"
+url = "/github/"
+weight = 1
+
+[[menu.main]]
 name = "About"
 identifier = "about"
-weight = 1
+weight = 2
 
 [[menu.main]]
 name = "Overview"
@@ -74,7 +79,7 @@ weight = 6
 [[menu.main]]
 name = "Getting started"
 identifier = "getting-started"
-weight = 2
+weight = 3
 
 [[menu.main]]
 name = "Security"
@@ -122,7 +127,7 @@ weight = 7
 [[menu.main]]
 name = "Community"
 identifier = "community"
-weight = 3
+weight = 4
 
 [[menu.main]]
 name = "Adoptions"
@@ -163,9 +168,9 @@ weight = 6
 [[menu.main]]
 name = "News"
 url = "/news/"
-weight = 4
+weight = 5
 
 [[menu.main]]
 name = "Contact"
 url = "/contact/"
-weight = 5
+weight = 6

--- a/config.toml
+++ b/config.toml
@@ -106,7 +106,6 @@ parent = "getting-started"
 url = "/specification/list"
 weight = 5
 
-
 [[menu.main]]
 name = "Implementations"
 parent = "getting-started"
@@ -149,16 +148,22 @@ url = "/taps"
 weight = 4
 
 [[menu.main]]
-name = "Contribute"
-parent = "community"
-url = "https://github.com/theupdateframework/python-tuf"
-weight = 5
-
-[[menu.main]]
 name = "GitHub"
 parent = "community"
 url = "/github"
+weight = 5
+
+[[menu.main]]
+name = "Contribute"
+parent = "community"
+url = "https://github.com/theupdateframework/python-tuf"
 weight = 6
+
+[[menu.main]]
+name = "Chat (CNCF Slack)"
+parent = "community"
+url = "https://cloud-native.slack.com/archives/C8NMD3QJ3"
+weight = 7
 
 [[menu.main]]
 name = "News"

--- a/content/_index.md
+++ b/content/_index.md
@@ -4,3 +4,5 @@
 The Update Framework (**TUF**) helps developers maintain the security of software update systems, providing protection even against attackers that compromise the repository or signing keys. TUF provides a flexible framework and [specification](https://theupdateframework.github.io/specification/latest/) that developers can adopt into any software update system.
 
 TUF is hosted by the [Linux Foundation](https://www.linuxfoundation.org/) as part of the [Cloud Native Computing Foundation](https://www.cncf.io) (CNCF) and is [used in production](/adoptions) by various tech companies and open source organizations. A variant of TUF called [Uptane](https://uptane.github.io/) is widely used to secure over-the-air updates in automobiles.
+
+>  [**TUF GitHub**](https://github.com/theupdateframework) 

--- a/content/_index.md
+++ b/content/_index.md
@@ -4,5 +4,3 @@
 The Update Framework (**TUF**) helps developers maintain the security of software update systems, providing protection even against attackers that compromise the repository or signing keys. TUF provides a flexible framework and [specification](https://theupdateframework.github.io/specification/latest/) that developers can adopt into any software update system.
 
 TUF is hosted by the [Linux Foundation](https://www.linuxfoundation.org/) as part of the [Cloud Native Computing Foundation](https://www.cncf.io) (CNCF) and is [used in production](/adoptions) by various tech companies and open source organizations. A variant of TUF called [Uptane](https://uptane.github.io/) is widely used to secure over-the-air updates in automobiles.
-
->  [**TUF GitHub**](https://github.com/theupdateframework) 

--- a/content/github.md
+++ b/content/github.md
@@ -1,0 +1,23 @@
+---
+title: Join TUF GitHub
+---
+
+### Check out [theupdateframework](https://github.com/theupdateframework) GitHub repositories:
+
+> ## [python-tuf Repository](https://github.com/theupdateframework/python-tuf)
+
+> ## [specification Repository](https://github.com/theupdateframework/specification)
+
+> ## [theupdateframework.io Repository](https://github.com/theupdateframework/theupdateframework.io)
+
+> ## [community Repository](https://github.com/theupdateframework/community)
+
+> ## [taps Repository](https://github.com/theupdateframework/taps)
+
+> ## [tuf-on-ci Repository](https://github.com/theupdateframework/tuf-on-ci)
+
+> ## [rust-tuf Repository](https://github.com/theupdateframework/rust-tuf)
+
+> ## [go-tuf Repository](https://github.com/theupdateframework/go-tuf)
+
+> ## [tuf-js Repository](https://github.com/theupdateframework/tuf-js)

--- a/content/github.md
+++ b/content/github.md
@@ -5,19 +5,28 @@ title: Join TUF GitHub
 ### Check out [theupdateframework](https://github.com/theupdateframework) GitHub repositories:
 
 > ## [python-tuf Repository](https://github.com/theupdateframework/python-tuf)
+> this repository is a reference implementation written in python
 
 > ## [specification Repository](https://github.com/theupdateframework/specification)
+> The Update Framework specification
 
 > ## [theupdateframework.io Repository](https://github.com/theupdateframework/theupdateframework.io)
+> Website assets for TUF
 
 > ## [community Repository](https://github.com/theupdateframework/community)
+> Community repository of TUF
 
 > ## [taps Repository](https://github.com/theupdateframework/taps)
+> TUF Augmentation Proposals (TAPs)
 
 > ## [tuf-on-ci Repository](https://github.com/theupdateframework/tuf-on-ci)
+> A TUF repository and signing tool
 
 > ## [rust-tuf Repository](https://github.com/theupdateframework/rust-tuf)
+> Rust implementation of The Update Framework (TUF)
 
 > ## [go-tuf Repository](https://github.com/theupdateframework/go-tuf)
+> Go implementation of The Update Framework (TUF)
 
 > ## [tuf-js Repository](https://github.com/theupdateframework/tuf-js)
+> JavaScript implementation of the Update Framework (TUF)

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
 {{ $copy := site.Params.copyright | markdownify }}
 <footer class="footer has-background-black">
   <div class="container">
-    <div class="content has-text-light">
+    <div class="content is-copyright has-text-light">
       <div class="social-icons" style="margin-bottom: 20px;">
         <a href="/github" rel="noopener noreferrer" style="margin-right: 10px;">
           <i class="fab fa-github fa-2x has-text-light"></i>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,7 +17,7 @@
       </p>
 
       <p class="has-text-weight-bold">
-        &copy; {{ $year }} The Linux Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page.
+        &copy; {{ $year }} The Linux Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. 
       </p>
 
       <hr class="thick" />

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,13 +2,22 @@
 {{ $copy := site.Params.copyright | markdownify }}
 <footer class="footer has-background-black">
   <div class="container">
-    <div class="content is-copyright has-text-light">
+    <div class="content has-text-light">
+      <div class="social-icons" style="margin-bottom: 20px;">
+        <a href="/github" rel="noopener noreferrer" style="margin-right: 10px;">
+          <i class="fab fa-github fa-2x has-text-light"></i>
+        </a>
+        <a href="https://cloud-native.slack.com/archives/C8NMD3QJ3" target="_blank" rel="noopener noreferrer">
+          <i class="fab fa-slack fa-2x has-text-light"></i>
+        </a>
+      </div>
+
       <p class="has-text-weight-bold">
         &copy; {{ $year }} The Update Framework authors | Documentation Distributed under CC-BY-4.0
       </p>
 
       <p class="has-text-weight-bold">
-        &copy; {{ $year }} The Linux Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. 
+        &copy; {{ $year }} The Linux Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page.
       </p>
 
       <hr class="thick" />
@@ -17,3 +26,6 @@
     </div>   
   </div>
 </footer>
+
+<!-- Include FontAwesome -->
+<script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
Adding GitHub on main page and main menu.
This PR will solve  [Add a more explicit Github link to the website #28 ](https://github.com/theupdateframework/theupdateframework.io/issues/28) issue.
fixes #28 