### PR TITLE
remove deprecated features

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 title = "The Update Framework"
-disableKinds = ["section", "taxonomy", "taxonomyTerm"]
+disableKinds = ["section", "taxonomy"]
 baseURL = "https://theupdateframework.io"
 
 [markup.goldmark.renderer]

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,4 +1,4 @@
-{{- $inServerMode := site.IsServer }}
+{{- $inServerMode := hugo.IsServer }}
 {{- $includePaths := (slice "node_modules") }}
 {{- $sass         := "sass/style.sass" }}
 {{- $cssOutput    := "css/style.css" }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.60.0"
+HUGO_VERSION = "0.126.0"
 
 [context.deploy-preview]
 command = "make preview-build"


### PR DESCRIPTION
We have some deprecated features in our website source code, which become deprecated after hugo v0.120 and will removed in further release. Currently hugo comes with v0.126 