### PR TITLE
[docsy] Create assets/scss file to hold inline styles

### DIFF
--- a/assets/scss/_csp.scss
+++ b/assets/scss/_csp.scss
@@ -1,0 +1,23 @@
+// Due to the site's Content-Security-Policy, we must move inline styles
+// into this file. For some context, see:
+// https://github.com/theupdateframework/theupdateframework.io/issues/73
+
+// The following styles appear in the HTML generated for the ...
+
+// Navbar
+
+.navbar-logo > svg .st0 {
+  fill: white;
+}
+
+// Homepage: it will need to be updated when the hero image is changed.
+
+#td-cover-block-0 {
+  background-image: url(/featured-background_hu18408291696259244493.jpg)
+}
+
+@media only screen and (min-width:1200px) {
+  #td-cover-block-0 {
+    background-image: url(/featured-background_hu16056391159218873026.jpg)
+  }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,4 +1,5 @@
 @import 'td/code-dark';
+@import 'csp';
 
 .td-navbar {
   .navbar-brand {

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -4,9 +4,10 @@ description: A framework for securing software update systems
 outputs:
   - HTML
   - REDIRECTS # Include this `content/en` ONLY
-developer_note:
+developer_note: |
   The blocks/cover shortcode (used below) will use as a background image any
   image file containing "background" in its name.
+  Current image source: https://www.pexels.com/photo/close-up-photo-of-programming-of-codes-546819
 ---
 
 {{% blocks/cover title="The Update Framework" image_anchor="top" color="primary" height="max" %}}


### PR DESCRIPTION
- Fixes #73
- Adds a link to the URL from which the hero image was taken. As you can see from the website, we have permission to use the image.

### Screenshots

Notice the hero image fix, and the TUF logo color fix.

Before:

> <img width="500" alt="image" src="https://github.com/user-attachments/assets/45f86496-9191-4fcb-a8fe-f27d8c6da88c">


After:

> <img width="500" alt="image" src="https://github.com/user-attachments/assets/4374cd88-776e-4af5-8523-1c0215b8156b">

