### PR TITLE
[docsy] Add About page to hold project and grant info

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -23,5 +23,6 @@ languageSettings:
     ignoreRegExpList:
       - CodeBlock
 words:
+  - Cappos
   - CNCF
   - Docsy

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -8,3 +8,4 @@ IgnoreInternalEmptyHash: true # FIXME
 IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://twitter.com/docsydocs$
+  - ^/specs

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -16,7 +16,7 @@ developer_note: |
 {{% param description %}}
 {.display-6}
 
-<a class="btn btn-lg btn-primary me-3" href="docs/">Learn More</a>
+<a class="btn btn-lg btn-primary me-3" href="docs/overview/">Learn More</a>
 <a class="btn btn-lg btn-secondary" href="docs/get-started/">Get started</a>
 {.p-initial .my-5}
 
@@ -24,11 +24,7 @@ developer_note: |
 
 {{% blocks/lead color="tertiary" %}}
 
-The Update Framework (TUF) maintains the security of software update systems,
-providing protection even against attackers that compromise the repository or
-signing keys. TUF provides a flexible framework and
-[specification](https://theupdateframework.github.io/specification/latest/) that
-developers can adopt into any software update system.
+{{% param whatIsTUF %}}
 
 {{% /blocks/lead %}}
 

--- a/content/en/about.md
+++ b/content/en/about.md
@@ -1,0 +1,17 @@
+---
+title: About The Update Framework
+linkTitle: About
+menu: { main: { weight: 10 } }
+---
+
+{{% blocks/cover title="About The Update Framework" height="auto" %}}
+
+{{% /blocks/cover %}}
+
+{{% blocks/section color="white" %}}
+
+{{% param whatIsTUF %}} [Learn more](/docs/overview/).
+
+{{% param projectAndGrants %}}
+
+{{% /blocks/section %}}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -38,6 +38,34 @@ languages:
     languageCode: en-US
     params:
       description: A Framework for securing software update systems
+      whatIsTUF: |
+        The Update Framework (TUF) maintains the security of software update
+        systems, providing protection even against attackers that compromise the
+        repository or signing keys. TUF provides a flexible framework and
+        [specification](/specs/)
+        that developers can adopt into any software update system.
+      projectAndGrants: |
+        The TUF project is managed by the [Linux Foundation] under the [Cloud
+        Native Computing Foundation][CNCF]. The consensus builder for TUF is [Prof.
+        Justin Cappos](https://ssl.engineering.nyu.edu/personalpages/jcappos/)
+        of the [Secure Systems Lab](https://ssl.engineering.nyu.edu) at [New
+        York University](https://engineering.nyu.edu/). Project
+        maintainers [[1]][[2]]
+        are comprised of collaborators from academia and the industry.
+        Contributors and maintainers are governed by the [CNCF Community Code of
+        Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+        This material is based upon work supported by the [National Science
+        Foundation][NSF] under Grant Nos. CNS-1345049 and CNS-0959138. Any opinions,
+        findings, and conclusions or recommendations expressed in this material
+        are those of the author(s) and do not necessarily reflect the views of
+        the National Science Foundation.
+
+        [1]: https://github.com/theupdateframework/specification/blob/master/MAINTAINERS.md
+        [2]: https://github.com/theupdateframework/python-tuf/blob/develop/docs/MAINTAINERS.txt
+        [CNCF]: https://cncf.io
+        [Linux Foundation]: https://www.linuxfoundation.org
+        [NSF]: https://www.nsf.gov
 
 #
 # Markup and imaging
@@ -65,7 +93,7 @@ imaging:
 params:
   copyright:
     authors: >-
-      The Update Framework Authors| [CC BY
+      The Update Framework Authors | Docs [CC BY
       4.0](https://creativecommons.org/licenses/by/4.0) |
     # from_year: 2024
   github_repo: https://github.com/theupdateframework
@@ -85,25 +113,25 @@ params:
         Sorry to hear that. Please <a
         href="https://github.com/google/docsy/issues/new">tell us how we can
         improve</a>.
-  links: # CUSTOMIZE
+  links:
     user:
       - name: TUF Google group
         url: https://groups.google.com/g/theupdateframework
         icon: fa-solid fa-envelope
-        desc: Sign up for TUF announcements
+        desc: Sign up for TUF announcements.
       - name: Slack channel
         url: https://communityinviter.com/apps/cloud-native/cncf
         icon: fa-brands fa-slack
-        desc: Connect with us on CNCF Slack channel for TUF
+        desc: Connect with us on CNCF Slack channel for TUF.
       - name: Community meetings
         url: https://github.com/theupdateframework/community?tab=readme-ov-file
         icon: fa-regular fa-calendar-days
-        desc: Join our community meetings
+        desc: Join our community meetings.
     developer:
       - name: GitHub repository
         url: https://github.com/theupdateframework/theupdateframework.io
         icon: fa-brands fa-github
-        desc: Development takes place here!
+        desc: Website repository.
 
 module:
   mounts:


### PR DESCRIPTION
- Contributes to #85 
- Adds an **About** page to hold the grant (and other) info previously on the homepage footer
- **Preview**: https://deploy-preview-86--theupdateframework.netlify.app/about/