### PR TITLE
[docsy] About section rework: add headers

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -12,6 +12,32 @@ menu: { main: { weight: 10 } }
 
 {{% param whatIsTUF %}} [Learn more](/docs/overview/).
 
-{{% param projectAndGrants %}}
+## Governance
+
+The TUF project is managed by the [Linux Foundation] under the [Cloud Native Computing
+Foundation][CNCF]. The consensus builder for TUF is [Prof. Justin Cappos] of the
+[Secure Systems Lab] at [New York University](https://engineering.nyu.edu/). Project
+maintainers <sup>[[1]][[2]]</sup> are comprised of collaborators from academia and
+the industry. Contributors and maintainers are governed by the [CNCF Community Code
+of Conduct][CoC].
+
+## Funding
+
+This material is based upon work supported by the [National Science
+Foundation][NSF] under Grant Nos. CNS-1345049 and CNS-0959138. Any opinions,
+findings, and conclusions or recommendations expressed in this material are
+those of the author(s) and do not necessarily reflect the views of the National
+Science Foundation.
+
+[1]:
+  https://github.com/theupdateframework/specification/blob/master/MAINTAINERS.md
+[2]:
+  https://github.com/theupdateframework/python-tuf/blob/develop/docs/MAINTAINERS.txt
+[CNCF]: https://cncf.io
+[CoC]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
+[Linux Foundation]: https://www.linuxfoundation.org
+[NSF]: https://www.nsf.gov
+[Prof. Justin Cappos]: https://ssl.engineering.nyu.edu/personalpages/jcappos/
+[Secure Systems Lab]: https://ssl.engineering.nyu.edu
 
 {{% /blocks/section %}}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -44,28 +44,6 @@ languages:
         repository or signing keys. TUF provides a flexible framework and
         [specification](/specification/latest)
         that developers can adopt into any software update system.
-      projectAndGrants: |
-        The TUF project is managed by the [Linux Foundation] under the [Cloud
-        Native Computing Foundation][CNCF]. The consensus builder for TUF is [Prof.
-        Justin Cappos](https://ssl.engineering.nyu.edu/personalpages/jcappos/)
-        of the [Secure Systems Lab](https://ssl.engineering.nyu.edu) at [New
-        York University](https://engineering.nyu.edu/). Project
-        maintainers [[1]][[2]]
-        are comprised of collaborators from academia and the industry.
-        Contributors and maintainers are governed by the [CNCF Community Code of
-        Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
-
-        This material is based upon work supported by the [National Science
-        Foundation][NSF] under Grant Nos. CNS-1345049 and CNS-0959138. Any opinions,
-        findings, and conclusions or recommendations expressed in this material
-        are those of the author(s) and do not necessarily reflect the views of
-        the National Science Foundation.
-
-        [1]: https://github.com/theupdateframework/specification/blob/master/MAINTAINERS.md
-        [2]: https://github.com/theupdateframework/python-tuf/blob/develop/docs/MAINTAINERS.txt
-        [CNCF]: https://cncf.io
-        [Linux Foundation]: https://www.linuxfoundation.org
-        [NSF]: https://www.nsf.gov
 
 #
 # Markup and imaging
@@ -93,8 +71,8 @@ imaging:
 params:
   copyright:
     authors: >-
-      The Update Framework Authors | Docs [CC BY
-      4.0](https://creativecommons.org/licenses/by/4.0) |
+      TUF Authors | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0) |
+      [Funding](/about/#funding) |
     # from_year: 2024
   github_repo: https://github.com/theupdateframework
   gcs_engine_id: 011217106833237091527:la2vtv2emlw # CUSTOMIZE # FIXME get an ID for the starter?


### PR DESCRIPTION
- Moves About section content from Hugo config into About.md file
- Adds headings to About section prose
- Adds to footer a link to NSF Funding in About page, now that there's a header to link to
- **Preview**: https://deploy-preview-89--theupdateframework.netlify.app/about/