### PR TITLE
[docsy] Configure Google Custom Search Engine but leave it disabled

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -83,7 +83,7 @@ params:
       [Funding](/docs/project/funding/) |
     # from_year: 2024
   github_repo: &repo https://github.com/theupdateframework/theupdateframework.io
-  gcs_engine_id: 011217106833237091527:la2vtv2emlw # CUSTOMIZE # FIXME get an ID for the starter?
+  gcs_engine_id: 06ecafa260afd40f9
   privacy_policy: https://www.linuxfoundation.org/legal/privacy-policy
   ui:
     navbar_logo: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -83,7 +83,7 @@ params:
       [Funding](/docs/project/funding/) |
     # from_year: 2024
   github_repo: &repo https://github.com/theupdateframework/theupdateframework.io
-  gcs_engine_id: 06ecafa260afd40f9
+  gcs_engine_id: 06ecafa260afd40f9 # Also see layouts/partials/hooks/head-end.html
   privacy_policy: https://www.linuxfoundation.org/legal/privacy-policy
   ui:
     navbar_logo: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -83,7 +83,9 @@ params:
       [Funding](/docs/project/funding/) |
     # from_year: 2024
   github_repo: &repo https://github.com/theupdateframework/theupdateframework.io
-  gcs_engine_id: 06ecafa260afd40f9 # Also see layouts/partials/hooks/head-end.html
+  ## 2024-10-05 Disabling search until we agree on a viable solution. For context
+  ## see https://github.com/theupdateframework/theupdateframework.io/pull/92
+  # gcs_engine_id: 06ecafa260afd40f9 # Also see layouts/partials/hooks/head-end.html
   privacy_policy: https://www.linuxfoundation.org/legal/privacy-policy
   ui:
     navbar_logo: true

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,1 @@
+<script type="text/javascript" async src="https://cse.google.com/cse.js?cx={{ .Site.Params.gcs_engine_id }}"></script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,7 +16,7 @@ to = "https://theupdateframework.github.io/specification/:splat"
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self' code.jquery.com fonts.googleapis.com fonts.gstatic.com use.fontawesome.com app.netlify.com netlify-cdp-loader.netlify.app youtube.com; frame-src youtube.com www.youtube.com"
+    Content-Security-Policy = "default-src 'self' code.jquery.com fonts.googleapis.com fonts.gstatic.com cse.google.com www.google.com use.fontawesome.com app.netlify.com netlify-cdp-loader.netlify.app youtube.com; frame-src youtube.com www.youtube.com"
     X-Frame-Options = "deny"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "no-referrer-when-downgrade"


### PR DESCRIPTION
**NOTE**: as mentioned in subsequent comments, I can't get GCSE to work fully under the current CSP, so I've decided to leave in the partial code changes, but disable search entirely for now, until we find & agree upon a viable search solution.

- Contributes to #91 
- Console access: https://programmablesearchengine.google.com/controlpanel/overview?cx=06ecafa260afd40f9
- Notes: /cc @nate-double-u @JustinCappos 
  - Adds `cse.google.com ` as CSP enabled domain
  - @chalin added `projects@cncf.io` as an owner of the GCSE