### PR TITLE
[docsy] Recover missing security pages and create Security section

### DIFF
--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -1,7 +1,7 @@
 ---
 title: Frequently Asked Questions
 LinkTitle: FAQ
-weight: 45
+weight: 450
 description: Get your questions answered!
 aliases: [/faq]
 ---
@@ -138,8 +138,8 @@ in [TAP 4](https://github.com/theupdateframework/taps/blob/master/tap4.md).
 
 **12. Has there been a security audit of TUF?**
 
-The [Security Audits](docs/overview/security) page links to a few of the
-security audits of TUF.
+The [Security Audits](docs/security/) page links to a few of the security audits
+of TUF.
 
 **13. How can I try TUF?**
 

--- a/content/en/docs/get-started/_index.md
+++ b/content/en/docs/get-started/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Get started
-weight: 17
+weight: 200
 description: Get started with TUF based on your role.
 aliases: [/getting-started]
 ---

--- a/content/en/docs/get-started/adopter.md
+++ b/content/en/docs/get-started/adopter.md
@@ -2,11 +2,11 @@
 title: Adopter
 weight: 15
 description: Get started with TUF as an adopter.
+cSpell:ignore: RSTUF
 ---
 
-TUF provides a framework for integration of the
-[security](docs/overview/security) properties into new and existing content
-delivery systems.
+TUF provides a framework for integration of the [security](docs/security/)
+properties into new and existing content delivery systems.
 
 While some [adoptions](/community/adoptions/) integrate TUF by implementing the
 framework from scratch, others start from either a TUF implementation or from a

--- a/content/en/docs/history.md
+++ b/content/en/docs/history.md
@@ -1,6 +1,6 @@
 ---
 title: History
-weight: 18
+weight: 418
 description: Learn TUF history and core principles
 aliases: [/history]
 ---

--- a/content/en/docs/overview/_index.md
+++ b/content/en/docs/overview/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-weight: 10
+weight: 100
 description: Find out what TUF is all about!
 aliases: [/overview]
 ---
@@ -80,8 +80,8 @@ account, such as when:
 - An attacker compromises the key used to sign these files. Now you download a
   file that is properly signed, but is still malicious.
 
-The [Security](docs/overview/security) section offers a full list of the attacks
-and updater weaknesses that TUF is designed to defend against.
+The [Security](docs/security/) section offers a full list of the attacks and
+updater weaknesses that TUF is designed to defend against.
 
 ### How does TUF secure updates?
 

--- a/content/en/docs/security/_index.md
+++ b/content/en/docs/security/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Security
-weight: 35
+weight: 300
 description: Security properties of TUF repositories
 aliases: [/security]
 ---

--- a/content/en/docs/security/audits.md
+++ b/content/en/docs/security/audits.md
@@ -1,0 +1,15 @@
+---
+title: Security audits
+linkTitle: Audits
+aliases: [/audits]
+---
+
+Selected publicly available audit reports:
+
+- [September 9, 2022 by X41](/audits/x41-python-tuf-audit-2022-09-09.pdf)
+- [August 7, 2018 by Cure53](https://github.com/theupdateframework/notary/blob/master/docs/resources/cure53_tuf_notary_audit_2018_08_07.pdf)
+  covering TUF and Notary
+- [October 18, 2017 by NCC](https://www.nccgroup.trust/globalassets/our-research/us/public-reports/2017/ncc-group-kolide-the-update-framework-security-assessment.pdf)
+  security assessment of TUF / Kolide.
+- [July 31, 2015 by NCC](https://github.com/theupdateframework/notary/blob/master/docs/resources/ncc_docker_notary_audit_2015_07_31.pdf)
+  covering TUF and Notary.

--- a/content/en/docs/security/reporting.md
+++ b/content/en/docs/security/reporting.md
@@ -1,0 +1,17 @@
+---
+title: Reporting issues
+aliases: [/reporting]
+---
+
+Security issues can be reported by emailing
+[jcappos@nyu.edu](mailto:jcappos@nyu.edu).
+
+If at all possible, please include the following information in the report:
+
+- Description of the vulnerability.
+- Steps to reproduce the issue.
+
+Optionally, emailed reports can be encrypted with PGP. Use this PGP key
+fingerprint:
+
+**E9C0 59EC 0D32 64FA B35F 94AD 465B F9F6 F8EB 475A**.

--- a/content/en/docs/timeline.md
+++ b/content/en/docs/timeline.md
@@ -1,6 +1,6 @@
 ---
 title: Timeline
-weight: 19
+weight: 419
 Description: See the project timeline
 aliases: [/timeline]
 ---


### PR DESCRIPTION
- Contributes to #93 
- Fixes #94
- Moves Security page to `/docs/security`
- Recovers (from original pre-Docsy site) the following pages and places them under the new Security section: audits.md, reporting.md
- **Preview**: https://deploy-preview-96--theupdateframework.netlify.app/docs/security/

### Screenshot

> <img width="1018" alt="image" src="https://github.com/user-attachments/assets/925273c2-77a9-4739-92af-cc2743477608">
