### PR TITLE
[docsy] Create Projects section under docs

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -10,7 +10,10 @@ menu: { main: { weight: 10 } }
 
 {{% blocks/section color="white" %}}
 
-{{% param whatIsTUF %}} [Learn more](/docs/overview/).
+{{% param whatIsTUF %}}
+
+To learn more, see [TUF overview](/docs/overview/) and
+[project details](/docs/project/).
 
 ## Governance
 
@@ -19,15 +22,11 @@ Foundation][CNCF]. The consensus builder for TUF is [Prof. Justin Cappos] of the
 [Secure Systems Lab] at [New York University](https://engineering.nyu.edu/). Project
 maintainers <sup>[[1]][[2]]</sup> are comprised of collaborators from academia and
 the industry. Contributors and maintainers are governed by the [CNCF Community Code
-of Conduct][CoC].
+of Conduct][CoC]. For details, see [Governance].
 
 ## Funding
 
-This material is based upon work supported by the [National Science
-Foundation][NSF] under Grant Nos. CNS-1345049 and CNS-0959138. Any opinions,
-findings, and conclusions or recommendations expressed in this material are
-those of the author(s) and do not necessarily reflect the views of the National
-Science Foundation.
+{{% param funding %}}
 
 [1]:
   https://github.com/theupdateframework/specification/blob/master/MAINTAINERS.md
@@ -35,8 +34,9 @@ Science Foundation.
   https://github.com/theupdateframework/python-tuf/blob/develop/docs/MAINTAINERS.txt
 [CNCF]: https://cncf.io
 [CoC]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
+[Governance]:
+  https://github.com/theupdateframework/specification/blob/master/GOVERNANCE.md
 [Linux Foundation]: https://www.linuxfoundation.org
-[NSF]: https://www.nsf.gov
 [Prof. Justin Cappos]: https://ssl.engineering.nyu.edu/personalpages/jcappos/
 [Secure Systems Lab]: https://ssl.engineering.nyu.edu
 

--- a/content/en/docs/project/_index.md
+++ b/content/en/docs/project/_index.md
@@ -1,9 +1,7 @@
 ---
 title: Project
-LinkTitle: Project
-weight: 20
-description: Learn more about the TUF project
-liases: [/project]
+aliases: [/project]
+weight: 400
 ---
 
 The TUF project consists of three components:
@@ -25,12 +23,12 @@ academics, professional developers, and contributors from the open-source
 community. We especially acknowledge the individuals from the open-source
 community who have [contributed] to the TUF project over the years.
 
-Please visit the [governance page] to learn how project decisions are made, and for
-a more detailed explanation of the project roles used below.
+To learn how project decisions are made, and for a more detailed explanation of
+the project roles used below, see [Governance].
 
 [contributed]:
   https://github.com/theupdateframework/python-tuf/blob/develop/docs/AUTHORS.txt
-[governance page]:
+[Governance]:
   https://github.com/theupdateframework/specification/blob/master/GOVERNANCE.md
 [Specification]: https://theupdateframework.github.io/specification/latest
 [Standardization process]:
@@ -41,11 +39,9 @@ a more detailed explanation of the project roles used below.
 
 ### Justin Cappos
 
-Email: jcappos@nyu.edu
-
-GitHub username: [JustinCappos](https://github.com/justincappos)
-
-PGP fingerprint: E9C0 59EC 0D32 64FA B35F 94AD 465B F9F6 F8EB 475A
+Email: [jcappos@nyu.edu](mailto:jcappos@nyu.edu)<br> GitHub username:
+[JustinCappos](https://github.com/justincappos)<br> PGP fingerprint:
+`E9C0 59EC 0D32 64FA B35F 94AD 465B F9F6 F8EB 475A`
 
 ## Maintainers
 

--- a/content/en/docs/project/funding.md
+++ b/content/en/docs/project/funding.md
@@ -1,0 +1,6 @@
+---
+title: Funding
+aliases: [/funding]
+---
+
+{{% param funding %}}

--- a/content/en/docs/project/history.md
+++ b/content/en/docs/project/history.md
@@ -1,16 +1,15 @@
 ---
 title: History
-weight: 418
-description: Learn TUF history and core principles
+description: TUF history and core principles
 aliases: [/history]
+cSpell:ignore: Dingledine Tandon Trishank Karthik Kuppusamy Diaz Sebastien Awwad
 ---
 
 The basic technology behind TUF was developed at the University of Washington in
-2009 by Justin Samuel and Justin Cappos, and presented in a
-[paper](https://theupdateframework.github.io/papers/survivable-key-compromise-ccs2010.pdf?raw=true)
-Samuel and Cappos coauthored with Nick Mathewson and Roger Dingledine,
-researchers from [The Tor Project, Inc](https://www.torproject.org/). Since
-2011, TUF has been based at
+2009 by Justin Samuel and Justin Cappos, and presented in a [paper] Samuel and
+Cappos coauthored with Nick Mathewson and Roger Dingledine, researchers from
+[The Tor Project, Inc](https://www.torproject.org/). Since 2011, TUF has been
+based at
 [New York University Tandon School of Engineering](https://engineering.nyu.edu/),
 where Cappos is a tenured associate professor of computer science and
 engineering. There he works with a team of Ph.D. students, including Trishank
@@ -35,3 +34,6 @@ four core principles continue to be central to its design.
 - Lastly, TUF keeps the most vulnerable signing keys offline, which greatly
   reduces the risk that they can be stolen or compromised. In 2016, the TUF
   research group set up a process whereby the community could
+
+[paper]:
+  https://theupdateframework.github.io/papers/survivable-key-compromise-ccs2010.pdf?raw=true

--- a/content/en/docs/project/timeline.md
+++ b/content/en/docs/project/timeline.md
@@ -1,7 +1,5 @@
 ---
 title: Timeline
-weight: 419
-Description: See the project timeline
 aliases: [/timeline]
 ---
 

--- a/content/en/docs/security/reporting.md
+++ b/content/en/docs/security/reporting.md
@@ -4,6 +4,7 @@ aliases: [/reporting]
 ---
 
 Security issues can be reported by emailing
+[Justin Cappos](/docs/project/#justin-cappos) at
 [jcappos@nyu.edu](mailto:jcappos@nyu.edu).
 
 If at all possible, please include the following information in the report:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -44,6 +44,14 @@ languages:
         repository or signing keys. TUF provides a flexible framework and
         [specification](/specification/latest)
         that developers can adopt into any software update system.
+      funding: |
+        This material is based upon work supported by the [National Science
+        Foundation][NSF] under Grant Nos. CNS-1345049 and CNS-0959138. Any opinions,
+        findings, and conclusions or recommendations expressed in this material are
+        those of the author(s) and do not necessarily reflect the views of the National
+        Science Foundation.
+
+        [NSF]: https://www.nsf.gov
 
 #
 # Markup and imaging
@@ -72,7 +80,7 @@ params:
   copyright:
     authors: >-
       TUF Authors | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0) |
-      [Funding](/about/#funding) |
+      [Funding](/docs/project/funding/) |
     # from_year: 2024
   github_repo: https://github.com/theupdateframework
   gcs_engine_id: 011217106833237091527:la2vtv2emlw # CUSTOMIZE # FIXME get an ID for the starter?
@@ -85,11 +93,11 @@ params:
       enable: false # FIXME: setting to false until the feedback can be better configured
       'yes': >-
         Glad to hear it! Please <a
-        href="https://github.com/google/docsy/issues/new">tell us how we can
+        href="https://github.com/ORG/PROJECT/issues/new">tell us how we can
         improve</a>.
       'no': >-
         Sorry to hear that. Please <a
-        href="https://github.com/google/docsy/issues/new">tell us how we can
+        href="https://github.com/ORG/PROJECT/issues/new">tell us how we can
         improve</a>.
   links:
     user:


### PR DESCRIPTION
- Contributes to #93 
- Moves Project page to `/docs/project`
- Moves project pages to be under this new section.
- Adds a Funding subpage for greater visibility of funding sources
- **Preview**: https://deploy-preview-97--theupdateframework.netlify.app/docs/project/

### Screenshot

> <img width="1074" alt="image" src="https://github.com/user-attachments/assets/90b5ebee-6700-47a8-9737-edd89caccaa8">

