### PR TITLE
[docsy] Add Contact section

### DIFF
--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -2,7 +2,24 @@
 title: Community
 menu: { main: { weight: 40 } }
 cascade: { type: docs }
-contributingUrl: https://github.com/theupdateframework/community
+contributingUrl: https://github.com/theupdateframework/community/blob/main/CONTRIBUTING.md
+aliases: [/contact]
 ---
 
 {{% community-lists %}}
+
+## Contact
+
+- **[TUF Google group]** is the best way to reach us.
+- **General questions, feedback, and suggestions** are welcome on this low
+  volume mailing list or the
+  [#tuf](https://cloud-native.slack.com/archives/C8NMD3QJ3) channel on
+  [CNCF Slack](https://slack.cncf.io/).
+- **Specification**: we strive to make the specification easy to implement, so
+  if you come across any inconsistencies or experience any difficulty, do let us
+  know by sending an email, or by [creating an issue in the specification
+  repo][issue].
+
+[issue]: https://github.com/theupdateframework/specification/issues
+
+[TUF Google group]: {{% param "links.google_group" %}}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -100,9 +100,14 @@ params:
         href="https://github.com/ORG/PROJECT/issues/new">tell us how we can
         improve</a>.
   links:
+    google_group: &google_group https://groups.google.com/g/theupdateframework
     user:
+      - name: Contact
+        url: /community/#contact
+        icon: fa-solid fa-address-book
+        desc: Questions, feedback, and suggestions are welcome!
       - name: TUF Google group
-        url: https://groups.google.com/g/theupdateframework
+        url: *google_group
         icon: fa-solid fa-envelope
         desc: Sign up for TUF announcements.
       - name: Slack channel

--- a/layouts/shortcodes/community-lists.md
+++ b/layouts/shortcodes/community-lists.md
@@ -1,4 +1,5 @@
 {{ $links := .Site.Params.links -}}
+{{ $contribUrl := .Page.Params.contributingUrl | default "docs/contribution-guidelines" -}}
 
 <p>{{ T "community_introduce" . }}</p>
 
@@ -6,7 +7,7 @@
 
 {{ T "community_using" . }}
 
-{{ with index $links "user"}} 
+{{ with index $links "user"}}
     {{ template "community-links-list" . }}
 {{ end }}
 
@@ -14,15 +15,15 @@
 
 {{ T "community_contribute" . }}
 
-{{ with index $links "developer"}} 
+{{ with index $links "developer"}}
     {{ template "community-links-list" . }}
 {{ end }}
 
-{{ T "community_how_to" . }}{{ T "community_guideline" }}.
+{{ T "community_how_to" . }}
+[{{ T "community_guideline" }}]({{ $contribUrl | relURL }}).
 
-{{ define "community-links-list" -}} 
+{{ define "community-links-list" -}}
 {{ range . }}
-
-- [<i class="{{ .icon }}"></i> {{ .name }}]({{ .url }}): {{ .desc -}} 
-{{ end -}} 
+- [<i class="{{ .icon }}"></i> {{ .name }}]({{ .url }}): {{ .desc -}}
+{{ end -}}
 {{ end }}


### PR DESCRIPTION
- Contributes to #93 
- Adds an explicit Contact section (like the pre-Docsy version of the site had) in the Community page
- **Preview**: https://deploy-preview-99--theupdateframework.netlify.app/community/#contact