### PR TITLE
[docsy] Adjust links to spec, community contrib page, repo src

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -26,3 +26,4 @@ words:
   - Cappos
   - CNCF
   - Docsy
+  - Uptane

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -2,7 +2,7 @@
 title: Community
 menu: { main: { weight: 40 } }
 cascade: { type: docs }
-contributingUrl: https://github.com/theupdateframework/community/blob/main/CONTRIBUTING.md
+contributingUrl: /docs/contributing/
 aliases: [/contact]
 ---
 

--- a/content/en/docs/contributing.md
+++ b/content/en/docs/contributing.md
@@ -3,12 +3,13 @@ title: Contributing
 weight: 700
 ---
 
-There are many opportunities to contribute to TUF project. You can contribute to
-the [specification](/specification/) or [documentation](/docs/).
+There are several opportunities to contribute to the TUF project. You can
+contribute to the [specification](/specification/), [documentation](/docs/), or
+any one of the TUF implementations from the [TUF organization].
 
-For guidance on how to contribute, see the
-[TUF Contributor Guide](https://github.com/theupdateframework/community/blob/main/CONTRIBUTING.md).
+For guidance, see the [Community] repo [Contributing] page.
 
-For more information on how to contribute, reach out to the
-[TUF community site](/community/) or check out areas of contribution on GitHub
-[The Update Framework]({{% param github_repo %}}).
+[Community]: https://github.com/theupdateframework/community/
+[Contributing]:
+  https://github.com/theupdateframework/community/blob/main/CONTRIBUTING.md
+[TUF organization]: https://github.com/theupdateframework

--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -20,7 +20,7 @@ rotate offline keys), and how to periodically update and re-sign metadata.
 
 For (2), an adopter has to figure out how to ship the initial Root file, and
 implement
-[the TUF download and verification workflow](https://theupdateframework.github.io/specification/latest/#detailed-client-workflow)
+[the TUF download and verification workflow](/specification/latest/#detailed-client-workflow)
 in their language of choice if one of the existing implementations is
 insufficient.
 
@@ -116,7 +116,7 @@ bandwidth associated with downloading the large file many times can be saved.
 The reference implementation provides an
 [easy way to distribute target files across many targets metadata](https://github.com/theupdateframework/python-tuf/blob/v0.20.0/examples/repo_example/hashed_bin_delegation.py)
 (i.e., delegating to hashed bins), which the specification refers to as
-[path hash prefixes](https://theupdateframework.github.io/specification/latest/#path_hash_prefixes).
+[path hash prefixes](/specification/latest/#path_hash_prefixes).
 
 **10. Can TUF be used with devices that lack the CPU power or memory to verify
 metadata?**
@@ -138,8 +138,8 @@ in [TAP 4](https://github.com/theupdateframework/taps/blob/master/tap4.md).
 
 **12. Has there been a security audit of TUF?**
 
-The [Security Audits](docs/security/) page links to a few of the security audits
-of TUF.
+The [Security audits](docs/security/audits/) page links to a few of the security
+audits of TUF.
 
 **13. How can I try TUF?**
 
@@ -152,5 +152,5 @@ that demonstrate the usage.
 
 **14. Is there a presentation or video about TUF?**
 
-The [Videos]() page contains links to presentations that have been given by both
-TUF developer personnel, as well as adopters.
+The [Videos](/resources/videos/) page contains links to presentations that have
+been given by both TUF developer personnel, as well as adopters.

--- a/content/en/docs/project/_index.md
+++ b/content/en/docs/project/_index.md
@@ -30,7 +30,7 @@ the project roles used below, see [Governance].
   https://github.com/theupdateframework/python-tuf/blob/develop/docs/AUTHORS.txt
 [Governance]:
   https://github.com/theupdateframework/specification/blob/master/GOVERNANCE.md
-[Specification]: https://theupdateframework.github.io/specification/latest
+[Specification]: /specification/latest
 [Standardization process]:
   https://github.com/theupdateframework/taps/blob/master/tap1.md
 [Reference implementation]: https://theupdateframework.readthedocs.io/en/latest/

--- a/content/en/resources/news.md
+++ b/content/en/resources/news.md
@@ -1,6 +1,7 @@
 ---
 title: News
 aliases: [/news, /press]
+cSpell:ignore: Sigstore
 ---
 
 ## Highlights
@@ -18,14 +19,12 @@ root, and shorter root key lifespan than traditional PKI models.
 
 **March 5, 2021**
 
-The
-[TUF specification](https://theupdateframework.github.io/specification/latest/index.html)
-is now published as a rich HTML document with a table of contents, syntax
-highlighting, cross-linking, and other features.
+The [TUF specification](/specification/latest/) is now published as a rich HTML
+document with a table of contents, syntax highlighting, cross-linking, and other
+features.
 
 The new publication machinery also maintains a
-[list of all versions ](https://theupdateframework.github.io/specification/)
-published since the format change.
+[list of all versions](/specification/list/) published since the format change.
 
 **October 30, 2020**
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -83,6 +83,7 @@ params:
       [Funding](/docs/project/funding/) |
     # from_year: 2024
   github_repo: &repo https://github.com/theupdateframework/theupdateframework.io
+  github_branch: docsy # FIXME - remove once this get merged into main
   ## 2024-10-05 Disabling search until we agree on a viable solution. For context
   ## see https://github.com/theupdateframework/theupdateframework.io/pull/92
   # gcs_engine_id: 06ecafa260afd40f9 # Also see layouts/partials/hooks/head-end.html


### PR DESCRIPTION
- Contributes to #85 
- Adjusts link to Contributing guidelines in Community page to refer to local Contributing page
- Adjusts links to spec by using local path instead of external URL
- Ensures that https://www.docsy.dev/docs/adding-content/repository-links are working, by adding a (temporary) config parameter identifying the `docsy` branch