### PR TITLE
[docsy] Spec page: make link to latest a button, tweak external link rules

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -12,6 +12,7 @@ IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored
   # Ignore Docsy-generated GitHub links for now
   - ^https?://github\.com/.*?/.*?/(new|edit)/ # view-page, edit-source etc
+  - ^https://github\.com/theupdateframework/.*?/commit/ # last mod
 
   # TUF
   - ^/specification/

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -51,3 +51,7 @@
 }
 
 $tuf-blue: #0082ca;
+
+a.spec-btn {
+  color: white !important;
+}

--- a/content/en/spec.md
+++ b/content/en/spec.md
@@ -1,6 +1,7 @@
 ---
 title: Specification
 linkTitle: Spec
+description: The Update Framework Specification
 menu: { main: { weight: 35 } }
 # See Netlify.toml for /specification/* redirect rules.
 ---
@@ -11,10 +12,10 @@ menu: { main: { weight: 35 } }
 
 {{% blocks/section color="white" %}}
 
-The following specification versions are available:
+{{% param description %}} versions:
 
-- [latest](/specification/latest/)
-- [draft](/specification/draft/)
+<a class="spec-btn btn btn-lg btn-secondary ms-3" href="/specification/latest/">Latest</a>
+
 - [v1.0.33](/specification/v1.0.33/)
 - [v1.0.32](/specification/v1.0.32/)
 - [v1.0.31](/specification/v1.0.31/)
@@ -31,6 +32,7 @@ The following specification versions are available:
 - [v1.0.19](/specification/v1.0.19/)
 - [v1.0.18](/specification/v1.0.18/)
 - [v1.0.17](/specification/v1.0.17/)
+- [draft](/specification/draft/)
 
 This list is also available from [Spec versions](/specification/list/).
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -227,42 +227,6 @@
     "StatusCode": 200,
     "LastSeen": "2024-10-05T11:08:26.869281-04:00"
   },
-  "https://github.com/theupdateframework/theupdateframework.io/commit/1a60f9e217196e19076edba9787f72019141277e": {
-    "StatusCode": 200,
-    "LastSeen": "2024-10-05T11:18:19.547637-04:00"
-  },
-  "https://github.com/theupdateframework/theupdateframework.io/commit/54cca6ae06640ad10d184f806a98172781dcb9e8": {
-    "StatusCode": 200,
-    "LastSeen": "2024-10-05T11:21:13.701008-04:00"
-  },
-  "https://github.com/theupdateframework/theupdateframework.io/commit/594a6ab705de31ac2b1475ad06f9f983d0b6979a": {
-    "StatusCode": 200,
-    "LastSeen": "2024-10-05T11:25:32.728605-04:00"
-  },
-  "https://github.com/theupdateframework/theupdateframework.io/commit/638b8a1d81632df4c27553044a2e43e3f7abe7c4": {
-    "StatusCode": 200,
-    "LastSeen": "2024-10-05T11:20:26.362325-04:00"
-  },
-  "https://github.com/theupdateframework/theupdateframework.io/commit/723e3323632abf6f52ecd44f25770e62bb523816": {
-    "StatusCode": 200,
-    "LastSeen": "2024-10-05T11:20:04.936087-04:00"
-  },
-  "https://github.com/theupdateframework/theupdateframework.io/commit/8b0f6bba08eef217c6c7fadceb75a24a8341b84a": {
-    "StatusCode": 200,
-    "LastSeen": "2024-10-05T11:09:30.506069-04:00"
-  },
-  "https://github.com/theupdateframework/theupdateframework.io/commit/8b69df3d004adafe2f29174da6635d22504343fc": {
-    "StatusCode": 200,
-    "LastSeen": "2024-10-05T11:09:09.404042-04:00"
-  },
-  "https://github.com/theupdateframework/theupdateframework.io/commit/b11cefd08a89dab8a70c09711eeff1df7d3cae1c": {
-    "StatusCode": 200,
-    "LastSeen": "2024-10-05T11:28:11.25347-04:00"
-  },
-  "https://github.com/theupdateframework/theupdateframework.io/commit/e135c87230816424c13d2c50588e0301748577d3": {
-    "StatusCode": 200,
-    "LastSeen": "2024-10-05T11:10:23.56726-04:00"
-  },
   "https://github.com/theupdateframework/theupdateframework.io/issues/new": {
     "StatusCode": 200,
     "LastSeen": "2024-10-05T11:09:03.913978-04:00"


### PR DESCRIPTION
- Contributes to #85
- Makes the link to the latest version of the spec more prominent by styling it as a button
- Don't check Last-updated commit links (and strip them from the current refcache)