### PR TITLE
Adjustments for page-meta links

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -11,7 +11,7 @@ IgnoreInternalEmptyHash: true # FIXME
 IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored
   # Ignore Docsy-generated GitHub links for now
-  - ^https?://github\.com/.*?/.*?/(new|edit)/ # view-page, edit-source etc
+  - ^https://github.com/theupdateframework/theupdateframework.io/(edit|new|tree) # view, edit page src, etc
   - ^https://github\.com/theupdateframework/.*?/commit/ # last mod
 
   # TUF

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -55,3 +55,7 @@ $tuf-blue: #0082ca;
 a.spec-btn {
   color: white !important;
 }
+
+.td-page-meta__child {
+  display: none !important;
+}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -83,7 +83,6 @@ params:
       [Funding](/docs/project/funding/) |
     # from_year: 2024
   github_repo: &repo https://github.com/theupdateframework/theupdateframework.io
-  github_branch: docsy # FIXME - remove once this get merged into main
   ## 2024-10-05 Disabling search until we agree on a viable solution. For context
   ## see https://github.com/theupdateframework/theupdateframework.io/pull/92
   # gcs_engine_id: 06ecafa260afd40f9 # Also see layouts/partials/hooks/head-end.html


### PR DESCRIPTION
- Final PR that fixes and closes #85
- Drops `github_branch` entry now that we're on `main`
- Adjusts `htmltest` ignore rules for the view/edit page source, etc
- Hides the "create child page" meta-page link

**Test**:

- Visit any doc page, such as https://deploy-preview-106--theupdateframework.netlify.app/docs/
- Click on "View page source". Expect to see the page source on GH (rather than a 404).