### PR TITLE
Update NPM packages, Hugo to 0.147.6

### DIFF
--- a/content/en/resources/news.md
+++ b/content/en/resources/news.md
@@ -127,7 +127,7 @@ DockerCon 2017.
 **October 10, 2016**
 
 Lily Guo and Riyaz Faizullabhoy from Docker gave a
-[talk](https://linuxconcontainerconeurope2016.sched.org/event/7oI1/software-update-security-when-the-going-gets-tough-get-tuf-going-riyaz-faizullabhoy-lily-guo-docker?iframe=no&w=i:100;&sidebar=yes&bg=no)
+[talk](https://linuxconcontainerconeurope2016.sched.org/event/7oI1/software-update-security-when-the-going-gets-tough-get-tuf-going-riyaz-faizullabhoy-lily-guo-docker)
 on TUF and Notary at LinuxCon+ContainerCon Europe 2016. Slides of their talk are
 available
 [here](https://schd.ws/hosted_files/linuxconcontainerconeurope2016/50/When%20the%20going%20gets%20tough%2C%20get%20TUF%20going%21%20Linuxcon%20EU.pdf).

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,4 +1,4 @@
-{{ template "_default/_markup/td-render-heading.html" . -}}
+{{ template "_markup/td-render-heading.html" . -}}
 
 {{/* By default, the markdown processor emits a heading on its own line, so we
 don't trim whitespace from the end of this template. */}}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "_check:links--warn": "npm run _check:links || (echo; echo 'WARNING: see link-checker output for issues.'; echo)",
     "_check:links:internal": "npm run __check:links",
     "_check:links": "HTMLTEST_ARGS='--log-level 1' npm run __check:links",
+    "_commit:public": "HASH=$(git rev-parse --short main); cd public && git add -A && git commit -m \"Site at $HASH\"",
     "_diff:check": "git diff --name-only --exit-code",
     "_filename-error": "echo 'ERROR: the following files violate naming conventions; fix using: `npm run fix:filenames`'; echo; npm run -s _ls-bad-filenames; exit 1",
     "_filenames-to-kebab-case": "find assets content -name '*_*' ! -name '[_.]*' -exec sh -c 'mv \"$1\" \"${1//_/-}\"' _ {} \\;",
@@ -43,15 +44,15 @@
     "update:pkgs": "npx npm-check-updates -u"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.20",
-    "cspell": "^8.16.0",
-    "hugo-extended": "0.139.0",
-    "postcss-cli": "^11.0.0",
-    "prettier": "^3.3.3"
+    "autoprefixer": "^10.4.21",
+    "cspell": "^9.0.2",
+    "hugo-extended": "0.147.6",
+    "postcss-cli": "^11.0.1",
+    "prettier": "^3.5.3"
   },
   "optionalDependencies": {
-    "netlify-cli": "^17.37.2",
-    "npm-check-updates": "^17.1.11"
+    "netlify-cli": "^22.1.3",
+    "npm-check-updates": "^18.0.1"
   },
   "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",
   "engines": {

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -63,9 +63,9 @@
     "StatusCode": 206,
     "LastSeen": "2024-10-05T11:11:49.225551-04:00"
   },
-  "https://en.wikipedia.org/wiki/Glob_(programming)": {
+  "https://en.wikipedia.org/wiki/Glob_%28programming%29": {
     "StatusCode": 200,
-    "LastSeen": "2024-10-05T11:26:36.378625-04:00"
+    "LastSeen": "2025-06-07T17:54:22.16666-04:00"
   },
   "https://engineering.nyu.edu/": {
     "StatusCode": 206,


### PR DESCRIPTION
- Updates of NPM packages, Hugo in particular
- Adjustment to render-hook template access
- Updates refcache.json
- Drops unnecessary query param on an (old) new URL
- (Docsy update will be due after this PR.)