### PR TITLE
Fix broken relative link resolution in section docs and community shortcode (fixes #146)

### DIFF
--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -138,7 +138,7 @@ in [TAP 4](https://github.com/theupdateframework/taps/blob/master/tap4.md).
 
 **12. Has there been a security audit of TUF?**
 
-The [Security audits](docs/security/audits/) page links to a few of the security
+The [Security audits](/docs/security/audits/) page links to a few of the security
 audits of TUF.
 
 **13. How can I try TUF?**

--- a/content/en/docs/overview.md
+++ b/content/en/docs/overview.md
@@ -80,7 +80,7 @@ account, such as when:
 - An attacker compromises the key used to sign these files. Now you download a
   file that is properly signed, but is still malicious.
 
-The [Security](docs/security/) section offers a full list of the attacks and
+The [Security](/docs/security/) section offers a full list of the attacks and
 updater weaknesses that TUF is designed to defend against.
 
 ### How does TUF secure updates?
@@ -97,4 +97,4 @@ understand what's going on underneath. TUF identifies the updates, downloads
 them, and checks them against the metadata that it also downloads from the
 repository. If the downloaded target files are trustworthy, TUF hands them over
 to your software update system. For more information and examples, see
-[Roles and metadata](docs/metadata/)
+[Roles and metadata](/docs/metadata/)

--- a/content/en/docs/security/_index.md
+++ b/content/en/docs/security/_index.md
@@ -77,7 +77,7 @@ system.
 To ensure systems are secure against all of the above attacks, the design and
 implementation of TUF relies on a few basic concepts. For details of how TUF
 conveys the information discussed below, see
-[Roles and metadata](docs/metadata/).
+[Roles and metadata](/docs/metadata/).
 
 ### Trust
 

--- a/layouts/_shortcodes/community-lists.md
+++ b/layouts/_shortcodes/community-lists.md
@@ -1,5 +1,5 @@
 {{ $links := .Site.Params.links -}}
-{{ $contribUrl := .Page.Params.contributingUrl | default "docs/contribution-guidelines" -}}
+{{ $contribUrl := .Page.Params.contributingUrl | default "/docs/contributing/" -}}
 
 <p>{{ T "community_introduce" . }}</p>
 


### PR DESCRIPTION
Fixes #146

## Summary

Several documentation pages and a layout shortcode used relative Markdown
links without a leading `/`. When Hugo renders a page under a nested route
such as `/docs/overview/` or `/community/`, the browser resolves relative
URLs against the current directory. This silently produces broken
destinations like `/docs/overview/docs/security/` or
`/community/docs/contribution-guidelines` instead of the intended pages.

## Changes

### Content

| File | Before | After |
|---|---|---|
| `content/en/docs/overview.md` | `docs/security/` | `/docs/security/` |
| `content/en/docs/overview.md` | `docs/metadata/` | `/docs/metadata/` |
| `content/en/docs/faq.md` | `docs/security/audits/` | `/docs/security/audits/` |
| `content/en/docs/security/_index.md` | `docs/metadata/` | `/docs/metadata/` |

### Layout shortcode

`layouts/_shortcodes/community-lists.md`: the `$contribUrl` default
fallback changed from `docs/contribution-guidelines` (a path-relative
string that resolves incorrectly from `/community/`) to `/docs/contributing/`
(a root-relative path that resolves correctly from any page).

## Testing

- `npm run check:format` passes with no warnings on the modified files.
- Links verified to resolve correctly at their rendered routes.

## Notes on `.htmltest.yml`

The link-checker config still carries `IgnoreDirectoryMissingTrailingSlash`,
`IgnoreEmptyHref`, and `IgnoreInternalEmptyHash` suppressions marked
`FIXME`. Those are pre-existing suppressions and are out of scope for this
PR; a follow-up issue or PR should address them separately once the
underlying Docsy-generated markup is audited.
