### PR TITLE
Fix typo: Uodates -> Updates in news.md

### DIFF
--- a/content/en/resources/news.md
+++ b/content/en/resources/news.md
@@ -243,7 +243,7 @@ For more information on the Docker + TUF integration, consult
 
 - [Forbes-January 2017: Uptane Will Protect your Connected Car from Hackers](https://www.forbes.com/sites/.../uptane-will-protect-your-connected-car-from-hackers)
 
-- [Christian Science Monitor-January 2017: Are Software Uodates Key to Stopping Criminal Car Hacks?](https://www.csmonitor.com/World/Passcode/2017/0118/Are-software-updates-key-to-stopping-criminal-car-hacks)
+- [Christian Science Monitor-January 2017: Are Software Updates Key to Stopping Criminal Car Hacks?](https://www.csmonitor.com/World/Passcode/2017/0118/Are-software-updates-key-to-stopping-criminal-car-hacks)
 
 - [YouTube-October 2016: Justin Cappos presents TUF and ongoing work in securing software updates in automobiles and the software supply chain at Docker's Distributed Systems Summit 2016 ](https://www.youtube.com/watch?v=Aryr0O6H_2U&list=PLkA60AVN3hh8oPas3cq2VA9xB7WazcIgs&index=9)
 


### PR DESCRIPTION
Small typo fix - the Christian Science Monitor link title in the News page read "Are Software Uodates Key to Stopping Criminal Car Hacks?" instead of "Updates".
One-line change in content/en/resources/news.md, no other changes.
