### PR TITLE
Fix broken Bottlerocket adoption link

### DIFF
--- a/data/adoptions.yaml
+++ b/data/adoptions.yaml
@@ -1,7 +1,7 @@
 main:
   - url: https://web.archive.org/web/20230922074223/https://docs.automotivelinux.org/en/pike/#03_Architecture_Guides/02_Security_Blueprint/09_Update_%28Over_The_Air%29/
     tag: AGL
-  - url: https://github.com/bottlerocket-os/bottlerocket/tree/develop/sources/updater
+  - url: https://github.com/bottlerocket-os/bottlerocket/blob/96bf303df357ac434ebcc619d676ecffa1c9bbcb/PUBLISHING.md#roles-and-keys
     tag: Bottlerocket
   - url: https://github.com/cnabio/cnab-spec/blob/cnab-security-1.0.0-ga/300-CNAB-security.md
     tag: CNAB

--- a/lychee.toml
+++ b/lychee.toml
@@ -28,7 +28,6 @@ exclude = [
   '^https://schd\.ws/hosted_files/linuxconcontainerconeurope2016/',        # 403
   '^https://www\.forbes\.com/sites/',                                      # 403
   '^https://www\.tmcnet\.com/usubmit/2019/05/28/8963021\.htm',             # 403
-  '^https://github\.com/bottlerocket-os/bottlerocket/tree/develop/sources/updater', # 404
   '^https://www\.d2pmagazine\.com/2020/04/02/6099/',                       # 404
   '^https://www\.just-auto\.com/news/here-and-uptane-team-on-automotiveiot-security_id188912\.aspx', # 404
   '^https://www\.linuxfoundation\.org/cloud-containers-virtualization/',   # 404


### PR DESCRIPTION
This PR fixes a 404 broken link for the Bottlerocket adoption entry in `data/adoptions.yaml` and cleans up the associated link-checker workaround. 
Fixes: #174 
